### PR TITLE
Deboogger show improvements

### DIFF
--- a/Deboogger.xcodeproj/project.pbxproj
+++ b/Deboogger.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				629A6C724D7EE0C256CD9035 /* UIWindow+Deboogger.m in Sources */,
 				849B836A1EC7564000B0DF9D /* SwitchPlugin.swift in Sources */,
 				849B836D1EC7564000B0DF9D /* PluginViewController.swift in Sources */,
 				840870441FD7B238007741AB /* SwitchTableViewCell.swift in Sources */,
@@ -347,7 +348,6 @@
 				849B835C1EC7564000B0DF9D /* BaseTextTableViewCell.swift in Sources */,
 				840870421FD7B238007741AB /* DescriptionTableViewCell.swift in Sources */,
 				629A673D3EBDAFECC1593719 /* UIWindow+Deboogger.swift in Sources */,
-				629A6C724D7EE0C256CD9035 /* UIWindow+Deboogger.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Deboogger.xcodeproj/project.pbxproj
+++ b/Deboogger.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		06D462662085DC610005009C /* Bundle+Deboogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D462652085DC610005009C /* Bundle+Deboogger.swift */; };
+		629A65CBC829B940726B0CD3 /* UIWindow+Deboogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 629A65FCE423F310729E625C /* UIWindow+Deboogger.h */; };
+		629A673D3EBDAFECC1593719 /* UIWindow+Deboogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629A6936E1B391DE557214E9 /* UIWindow+Deboogger.swift */; };
+		629A6C724D7EE0C256CD9035 /* UIWindow+Deboogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 629A63D44E7C17FA7B5D3789 /* UIWindow+Deboogger.m */; };
 		8408703F1FD7B238007741AB /* SegmentTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 840870341FD7B237007741AB /* SegmentTableViewCell.xib */; };
 		840870401FD7B238007741AB /* SegmentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840870351FD7B237007741AB /* SegmentTableViewCell.swift */; };
 		840870411FD7B238007741AB /* DescriptionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 840870371FD7B237007741AB /* DescriptionTableViewCell.xib */; };
@@ -39,6 +42,9 @@
 
 /* Begin PBXFileReference section */
 		06D462652085DC610005009C /* Bundle+Deboogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Deboogger.swift"; sourceTree = "<group>"; };
+		629A63D44E7C17FA7B5D3789 /* UIWindow+Deboogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIWindow+Deboogger.m"; sourceTree = "<group>"; };
+		629A65FCE423F310729E625C /* UIWindow+Deboogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIWindow+Deboogger.h"; sourceTree = "<group>"; };
+		629A6936E1B391DE557214E9 /* UIWindow+Deboogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWindow+Deboogger.swift"; sourceTree = "<group>"; };
 		840870341FD7B237007741AB /* SegmentTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SegmentTableViewCell.xib; sourceTree = "<group>"; };
 		840870351FD7B237007741AB /* SegmentTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentTableViewCell.swift; sourceTree = "<group>"; };
 		840870371FD7B237007741AB /* DescriptionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DescriptionTableViewCell.xib; sourceTree = "<group>"; };
@@ -203,6 +209,9 @@
 				849B83501EC7564000B0DF9D /* UIViewController+Presenter.swift */,
 				849B83721EC756DA00B0DF9D /* UIView+SuperviewOffset.swift */,
 				06D462652085DC610005009C /* Bundle+Deboogger.swift */,
+				629A6936E1B391DE557214E9 /* UIWindow+Deboogger.swift */,
+				629A63D44E7C17FA7B5D3789 /* UIWindow+Deboogger.m */,
+				629A65FCE423F310729E625C /* UIWindow+Deboogger.h */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -237,6 +246,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				849B83761EC7570E00B0DF9D /* Deboogger.h in Headers */,
+				629A65CBC829B940726B0CD3 /* UIWindow+Deboogger.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -336,6 +346,8 @@
 				849B83731EC756DA00B0DF9D /* UIView+SuperviewOffset.swift in Sources */,
 				849B835C1EC7564000B0DF9D /* BaseTextTableViewCell.swift in Sources */,
 				840870421FD7B238007741AB /* DescriptionTableViewCell.swift in Sources */,
+				629A673D3EBDAFECC1593719 /* UIWindow+Deboogger.swift in Sources */,
+				629A6C724D7EE0C256CD9035 /* UIWindow+Deboogger.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Deboogger.xcodeproj/project.pbxproj
+++ b/Deboogger.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		06D462662085DC610005009C /* Bundle+Deboogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D462652085DC610005009C /* Bundle+Deboogger.swift */; };
+		629A64CAA8FD70B7A8258DD6 /* DebooggerButtonPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629A6A2E6D28EB4A26442696 /* DebooggerButtonPlugin.swift */; };
 		629A65CBC829B940726B0CD3 /* UIWindow+Deboogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 629A65FCE423F310729E625C /* UIWindow+Deboogger.h */; };
 		629A673D3EBDAFECC1593719 /* UIWindow+Deboogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629A6936E1B391DE557214E9 /* UIWindow+Deboogger.swift */; };
 		629A6C724D7EE0C256CD9035 /* UIWindow+Deboogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 629A63D44E7C17FA7B5D3789 /* UIWindow+Deboogger.m */; };
@@ -45,6 +46,7 @@
 		629A63D44E7C17FA7B5D3789 /* UIWindow+Deboogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIWindow+Deboogger.m"; sourceTree = "<group>"; };
 		629A65FCE423F310729E625C /* UIWindow+Deboogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIWindow+Deboogger.h"; sourceTree = "<group>"; };
 		629A6936E1B391DE557214E9 /* UIWindow+Deboogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWindow+Deboogger.swift"; sourceTree = "<group>"; };
+		629A6A2E6D28EB4A26442696 /* DebooggerButtonPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebooggerButtonPlugin.swift; sourceTree = "<group>"; };
 		840870341FD7B237007741AB /* SegmentTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SegmentTableViewCell.xib; sourceTree = "<group>"; };
 		840870351FD7B237007741AB /* SegmentTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentTableViewCell.swift; sourceTree = "<group>"; };
 		840870371FD7B237007741AB /* DescriptionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DescriptionTableViewCell.xib; sourceTree = "<group>"; };
@@ -87,6 +89,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		629A65EF8623579554689BDA /* DefaultPlugins */ = {
+			isa = PBXGroup;
+			children = (
+				629A6A2E6D28EB4A26442696 /* DebooggerButtonPlugin.swift */,
+			);
+			path = DefaultPlugins;
+			sourceTree = "<group>";
+		};
 		840870331FD7B237007741AB /* SegmentTableViewCell */ = {
 			isa = PBXGroup;
 			children = (
@@ -178,6 +188,7 @@
 				8474585F1FE38E6100C3B0FA /* PluginViewController */,
 				8474585D1FE38B9D00C3B0FA /* Section.swift */,
 				849B834B1EC7564000B0DF9D /* Deboogger.swift */,
+				629A65EF8623579554689BDA /* DefaultPlugins */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -348,6 +359,7 @@
 				849B835C1EC7564000B0DF9D /* BaseTextTableViewCell.swift in Sources */,
 				840870421FD7B238007741AB /* DescriptionTableViewCell.swift in Sources */,
 				629A673D3EBDAFECC1593719 /* UIWindow+Deboogger.swift in Sources */,
+				629A64CAA8FD70B7A8258DD6 /* DebooggerButtonPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -481,7 +493,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.otbivnoe.Deboogger;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -500,7 +512,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.otbivnoe.Deboogger;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/DebooggerExample.xcodeproj/project.pbxproj
+++ b/Example/DebooggerExample.xcodeproj/project.pbxproj
@@ -383,7 +383,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = GPVA8JVMU3;
 				INFOPLIST_FILE = DebooggerExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.otbivnoe.DebooggerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -401,7 +401,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = GPVA8JVMU3;
 				INFOPLIST_FILE = DebooggerExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.otbivnoe.DebooggerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Sources/AssistiveButton/AssistiveButton.swift
+++ b/Sources/AssistiveButton/AssistiveButton.swift
@@ -79,7 +79,7 @@ final class AssistiveButton: UIButton {
     }
     
     private func stopTimer() {
-         alpha = 1.0
+        alpha = 1.0
         
         opacityTimer?.invalidate()
         opacityTimer = nil

--- a/Sources/Deboogger.swift
+++ b/Sources/Deboogger.swift
@@ -47,13 +47,15 @@ public final class Deboogger {
         return window
     }()
 
-    private weak var pluginViewController: PluginViewController?
+    weak var pluginViewController: PluginViewController?
     public var viewController: UIViewController? {
         return pluginViewController
     }
     public var navigationController: UINavigationController? {
         return pluginViewController?.navigationController
     }
+
+    var configuration: Configuration?
 
     private init() {}
 
@@ -95,6 +97,8 @@ public final class Deboogger {
     // MARK: - Helpers
 
     private func configure(with configuration: Configuration) {
+        self.configuration = configuration
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
 
             let button = AssistiveButton(tapHandler: { [unowned self] in

--- a/Sources/Deboogger.swift
+++ b/Sources/Deboogger.swift
@@ -33,12 +33,11 @@ private final class AssistiveButtonPresenterViewController: UIViewController {
 
 public final class Deboogger {
 
-    weak var assistiveButton: UIButton?
-
     public static let shared = Deboogger()
 
     private weak var rootViewController: UIViewController?
     private var assistiveButtonPresenterViewController = AssistiveButtonPresenterViewController()
+    private weak var assistiveButton: UIButton?
 
     private lazy var assistiveButtonWindow: UIWindow = {
         let size = AssistiveButton.Layout.size

--- a/Sources/Deboogger.swift
+++ b/Sources/Deboogger.swift
@@ -155,7 +155,6 @@ public final class Deboogger {
         self.configuration = configuration
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-
             let button = AssistiveButton(tapHandler: { [weak self] in
                 self?.show()
             })

--- a/Sources/Deboogger.swift
+++ b/Sources/Deboogger.swift
@@ -56,7 +56,7 @@ public final class Deboogger {
     }
 
     private var configuration: Configuration?
-    private var isCurrentlyShowing: Bool = false
+    private var isShowing: Bool = false
 
     private var _shouldShowAssistiveButton: Bool = false
     var shouldShowAssistiveButton: Bool {
@@ -113,7 +113,7 @@ public final class Deboogger {
         NotificationCenter.default.post(name: .DebooggerWillHide, object: nil)
 
         pluginViewController?.dismiss(animated: true, completion: { [unowned self] in
-            self.isCurrentlyShowing = false
+            self.isShowing = false
             self.assistiveButtonWindow.isHidden = !self.shouldShowAssistiveButton
             self.rootViewController?.endAppearanceTransition()
             NotificationCenter.default.post(name: .DebooggerDidHide, object: nil)
@@ -121,7 +121,7 @@ public final class Deboogger {
     }
 
     public func show() {
-        if isCurrentlyShowing {
+        if isShowing {
             close()
             return
         }
@@ -129,7 +129,7 @@ public final class Deboogger {
         guard let configuration = configuration else {
             return
         }
-        isCurrentlyShowing = true
+        isShowing = true
 
         let pluginViewController = PluginViewController(configuration: configuration)
         pluginViewController.closeEventHandler = { [weak self] in
@@ -146,6 +146,7 @@ public final class Deboogger {
             self.rootViewController?.endAppearanceTransition()
             NotificationCenter.default.post(name: .DebooggerDidShow, object: nil)
         }
+        self.assistiveButtonWindow.isHidden = true
     }
 
     // MARK: - Helpers

--- a/Sources/Deboogger.swift
+++ b/Sources/Deboogger.swift
@@ -33,6 +33,8 @@ private final class AssistiveButtonPresenterViewController: UIViewController {
 
 public final class Deboogger {
 
+    weak var assistiveButton: UIButton?
+
     public static let shared = Deboogger()
 
     private weak var rootViewController: UIViewController?
@@ -114,8 +116,13 @@ public final class Deboogger {
 
         pluginViewController?.dismiss(animated: true, completion: { [unowned self] in
             self.isShowing = false
-            self.assistiveButtonWindow.isHidden = !self.shouldShowAssistiveButton
             self.rootViewController?.endAppearanceTransition()
+            self.assistiveButtonWindow.isHidden = !self.shouldShowAssistiveButton
+            if let assistiveButton = self.assistiveButton {
+                assistiveButton.removeFromSuperview()
+                self.assistiveButtonWindow.addSubview(assistiveButton)
+            }
+
             NotificationCenter.default.post(name: .DebooggerDidHide, object: nil)
         })
     }
@@ -159,9 +166,9 @@ public final class Deboogger {
             let button = AssistiveButton(tapHandler: { [weak self] in
                 self?.show()
             })
-
             self.assistiveButtonWindow.isHidden = !self.shouldShowAssistiveButton
             self.assistiveButtonWindow.addSubview(button)
+            self.assistiveButton = button
         }
     }
 

--- a/Sources/DefaultPlugins/DebooggerButtonPlugin.swift
+++ b/Sources/DefaultPlugins/DebooggerButtonPlugin.swift
@@ -6,9 +6,13 @@ import Foundation
 
 final class DebooggerButtonPlugin: SwitchPlugin {
 
+    private enum Constants {
+        static let debooggerSuffix: String = "deboogger_"
+    }
+
     private var shouldShowDebooggerButton: Bool {
         get {
-            if let shouldShow = UserDefaults.standard.object(forKey: "deboogger_\(#function)") as? Bool {
+            if let shouldShow = UserDefaults.standard.object(forKey: Constants.debooggerSuffix + "\(#function)") as? Bool {
                 return shouldShow
             }
 
@@ -16,11 +20,11 @@ final class DebooggerButtonPlugin: SwitchPlugin {
             #if targetEnvironment(simulator)
                 shouldShow = true
             #endif
-            UserDefaults.standard.set(shouldShow, forKey: "deboogger_\(#function)")
+            UserDefaults.standard.set(shouldShow, forKey: Constants.debooggerSuffix + "\(#function)")
             return shouldShow
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: "deboogger_\(#function)")
+            UserDefaults.standard.set(newValue, forKey: Constants.debooggerSuffix + "\(#function)")
         }
     }
 

--- a/Sources/DefaultPlugins/DebooggerButtonPlugin.swift
+++ b/Sources/DefaultPlugins/DebooggerButtonPlugin.swift
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2019 Rosberry. All rights reserved.
+//
+
+import Foundation
+
+final class DebooggerButtonPlugin: SwitchPlugin {
+
+    private var shouldShowDebooggerButton: Bool {
+        get {
+            if let shouldShow = UserDefaults.standard.object(forKey: "deboogger_\(#function)") as? Bool {
+                return shouldShow
+            }
+
+            var shouldShow = false
+            #if targetEnvironment(simulator)
+                shouldShow = true
+            #endif
+            UserDefaults.standard.set(shouldShow, forKey: "deboogger_\(#function)")
+            return shouldShow
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "deboogger_\(#function)")
+        }
+    }
+
+    init() {
+        Deboogger.shared.shouldShowAssistiveButton = shouldShowDebooggerButton
+    }
+
+    var title: NSAttributedString = .init(string: "Show debug menu button on screen")
+    var isOn: Bool {
+        return shouldShowDebooggerButton
+    }
+
+    func switchStateChanged(_ sender: UISwitch) {
+        shouldShowDebooggerButton = sender.isOn
+        Deboogger.shared.shouldShowAssistiveButton = shouldShowDebooggerButton
+    }
+}

--- a/Sources/DefaultPlugins/DebooggerButtonPlugin.swift
+++ b/Sources/DefaultPlugins/DebooggerButtonPlugin.swift
@@ -7,12 +7,12 @@ import Foundation
 final class DebooggerButtonPlugin: SwitchPlugin {
 
     private enum Constants {
-        static let debooggerSuffix: String = "deboogger_"
+        static let debooggerPrefix: String = "deboogger_"
     }
 
     private var shouldShowDebooggerButton: Bool {
         get {
-            if let shouldShow = UserDefaults.standard.object(forKey: Constants.debooggerSuffix + "\(#function)") as? Bool {
+            if let shouldShow = UserDefaults.standard.object(forKey: Constants.debooggerPrefix + "\(#function)") as? Bool {
                 return shouldShow
             }
 
@@ -20,11 +20,11 @@ final class DebooggerButtonPlugin: SwitchPlugin {
             #if targetEnvironment(simulator)
                 shouldShow = true
             #endif
-            UserDefaults.standard.set(shouldShow, forKey: Constants.debooggerSuffix + "\(#function)")
+            UserDefaults.standard.set(shouldShow, forKey: Constants.debooggerPrefix + "\(#function)")
             return shouldShow
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: Constants.debooggerSuffix + "\(#function)")
+            UserDefaults.standard.set(newValue, forKey: Constants.debooggerPrefix + "\(#function)")
         }
     }
 

--- a/Sources/DefaultPlugins/DebooggerButtonPlugin.swift
+++ b/Sources/DefaultPlugins/DebooggerButtonPlugin.swift
@@ -16,10 +16,7 @@ final class DebooggerButtonPlugin: SwitchPlugin {
                 return shouldShow
             }
 
-            var shouldShow = false
-            #if targetEnvironment(simulator)
-                shouldShow = true
-            #endif
+            let shouldShow = Deboogger.shared.shouldShowAssistiveButton
             UserDefaults.standard.set(shouldShow, forKey: Constants.debooggerPrefix + "\(#function)")
             return shouldShow
         }

--- a/Sources/Extensions/UIWindow+Deboogger.h
+++ b/Sources/Extensions/UIWindow+Deboogger.h
@@ -1,0 +1,9 @@
+//
+// Copyright (c) 2019 Rosberry. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface UIWindow(Deboogger)
+@end

--- a/Sources/Extensions/UIWindow+Deboogger.h
+++ b/Sources/Extensions/UIWindow+Deboogger.h
@@ -6,4 +6,7 @@
 #import <UIKit/UIKit.h>
 
 @interface UIWindow(Deboogger)
+
+- (void)setupGestureRecognizer;
+
 @end

--- a/Sources/Extensions/UIWindow+Deboogger.h
+++ b/Sources/Extensions/UIWindow+Deboogger.h
@@ -2,7 +2,6 @@
 // Copyright (c) 2019 Rosberry. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface UIWindow(Deboogger)

--- a/Sources/Extensions/UIWindow+Deboogger.m
+++ b/Sources/Extensions/UIWindow+Deboogger.m
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2019 Rosberry. All rights reserved.
+//
+
+#import <objc/runtime.h>
+#import "UIWindow+Deboogger.h"
+
+@implementation UIWindow(Deboogger)
+
++ (void)swizzleMethodWithOriginalSelector:(SEL)originalSelector swizzledSelector:(SEL)swizzledSelector {
+    Method originalMethod = class_getInstanceMethod(self, originalSelector);
+    Method swizzledMethod = class_getInstanceMethod(self, swizzledSelector);
+    BOOL didAddMethod = class_addMethod(self, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod));
+    if (didAddMethod) {
+        class_replaceMethod(self, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod));
+    }
+    else {
+        method_exchangeImplementations(originalMethod, swizzledMethod);
+    }
+}
+
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [self swizzleMethodWithOriginalSelector:@selector(initWithFrame:)
+                               swizzledSelector:@selector(swizzled_initWithFrame:)];
+        [self swizzleMethodWithOriginalSelector:@selector(initWithCoder:)
+                               swizzledSelector:@selector(swizzled_initWithCoder:)];
+    });
+}
+
+@end

--- a/Sources/Extensions/UIWindow+Deboogger.m
+++ b/Sources/Extensions/UIWindow+Deboogger.m
@@ -4,6 +4,7 @@
 
 #import <objc/runtime.h>
 #import "UIWindow+Deboogger.h"
+#import <Deboogger/Deboogger-Swift.h>
 
 @implementation UIWindow(Deboogger)
 
@@ -27,6 +28,16 @@
         [self swizzleMethodWithOriginalSelector:@selector(initWithCoder:)
                                swizzledSelector:@selector(swizzled_initWithCoder:)];
     });
+}
+
+- (instancetype)swizzled_initWithFrame:(CGRect)frame {
+    [self setupGestureRecognizer];
+    return [self swizzled_initWithFrame:frame];
+}
+
+- (instancetype)swizzled_initWithCoder:(NSCoder *)aDecoder {
+    [self setupGestureRecognizer];
+    return [self swizzled_initWithCoder:aDecoder];
 }
 
 @end

--- a/Sources/Extensions/UIWindow+Deboogger.swift
+++ b/Sources/Extensions/UIWindow+Deboogger.swift
@@ -26,25 +26,6 @@ extension UIWindow {
     // MARK: Show/Hide
 
     @objc private func showDeboogger() {
-        let deboogger = Deboogger.shared
-        guard let configuration = deboogger.configuration else {
-            return
-        }
-
-        let pluginViewController = PluginViewController(configuration: configuration)
-        pluginViewController.closeEventHandler = { [weak deboogger] in
-            deboogger?.close()
-        }
-
-        let navigationController = UINavigationController(rootViewController: pluginViewController)
-        deboogger.pluginViewController = pluginViewController
-
-        self.rootViewController?.beginAppearanceTransition(false, animated: true)
-        NotificationCenter.default.post(name: .DebooggerWillShow, object: nil)
-
-        navigationController.present {
-            self.rootViewController?.endAppearanceTransition()
-            NotificationCenter.default.post(name: .DebooggerDidShow, object: nil)
-        }
+        Deboogger.shared.show()
     }
 }

--- a/Sources/Extensions/UIWindow+Deboogger.swift
+++ b/Sources/Extensions/UIWindow+Deboogger.swift
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2019 Rosberry. All rights reserved.
+//
+
+import UIKit
+
+extension UIWindow {
+
+    @objc private func swizzled_init(frame: CGRect) {
+        swizzled_init(frame: frame)
+        setupGestureRecognizer()
+    }
+
+    @objc private func swizzled_init(coder: NSCoder) {
+        swizzled_init(coder: coder)
+        setupGestureRecognizer()
+    }
+
+    private func setupGestureRecognizer() {
+        let recognizer = UITapGestureRecognizer(target: self, action: #selector(showDeboogger))
+        recognizer.numberOfTapsRequired = 2
+        recognizer.numberOfTouchesRequired = 4
+        addGestureRecognizer(recognizer)
+    }
+
+    // MARK: Show/Hide
+
+    @objc private func showDeboogger() {
+        let deboogger = Deboogger.shared
+        guard let configuration = deboogger.configuration else {
+            return
+        }
+
+        let pluginViewController = PluginViewController(configuration: configuration)
+        pluginViewController.closeEventHandler = { [weak deboogger] in
+            deboogger?.close()
+        }
+
+        let navigationController = UINavigationController(rootViewController: pluginViewController)
+        deboogger.pluginViewController = pluginViewController
+
+        self.rootViewController?.beginAppearanceTransition(false, animated: true)
+        NotificationCenter.default.post(name: .DebooggerWillShow, object: nil)
+
+        navigationController.present {
+            self.rootViewController?.endAppearanceTransition()
+            NotificationCenter.default.post(name: .DebooggerDidShow, object: nil)
+        }
+    }
+}

--- a/Sources/Extensions/UIWindow+Deboogger.swift
+++ b/Sources/Extensions/UIWindow+Deboogger.swift
@@ -6,20 +6,20 @@ import UIKit
 
 extension UIWindow {
 
-//    @objc private func swizzled_init(frame: CGRect) {
-//        swizzled_init(frame: frame)
-//        setupGestureRecognizer()
-//    }
-//
-//    @objc private func swizzled_init(coder: NSCoder) {
-//        swizzled_init(coder: coder)
-//        setupGestureRecognizer()
-//    }
+    private enum Constants {
+        static let numberOfTouches = 4
+        static let numberOfTaps = 2
+    }
 
     @objc private func setupGestureRecognizer() {
+        #if targetEnvironment(simulator)
+            return
+        #endif
+
         let recognizer = UITapGestureRecognizer(target: self, action: #selector(showDeboogger))
-        recognizer.numberOfTapsRequired = 2
-        recognizer.numberOfTouchesRequired = 4
+        recognizer.numberOfTapsRequired = Constants.numberOfTaps
+        recognizer.numberOfTouchesRequired = Constants.numberOfTouches
+        recognizer.requiresExclusiveTouchType = false
         addGestureRecognizer(recognizer)
     }
 

--- a/Sources/Extensions/UIWindow+Deboogger.swift
+++ b/Sources/Extensions/UIWindow+Deboogger.swift
@@ -6,17 +6,17 @@ import UIKit
 
 extension UIWindow {
 
-    @objc private func swizzled_init(frame: CGRect) {
-        swizzled_init(frame: frame)
-        setupGestureRecognizer()
-    }
+//    @objc private func swizzled_init(frame: CGRect) {
+//        swizzled_init(frame: frame)
+//        setupGestureRecognizer()
+//    }
+//
+//    @objc private func swizzled_init(coder: NSCoder) {
+//        swizzled_init(coder: coder)
+//        setupGestureRecognizer()
+//    }
 
-    @objc private func swizzled_init(coder: NSCoder) {
-        swizzled_init(coder: coder)
-        setupGestureRecognizer()
-    }
-
-    private func setupGestureRecognizer() {
+    @objc private func setupGestureRecognizer() {
         let recognizer = UITapGestureRecognizer(target: self, action: #selector(showDeboogger))
         recognizer.numberOfTapsRequired = 2
         recognizer.numberOfTouchesRequired = 4

--- a/Sources/PluginViewController/PluginViewController.swift
+++ b/Sources/PluginViewController/PluginViewController.swift
@@ -13,7 +13,7 @@ final class PluginViewController: UIViewController {
         tableView.delegate = configuration
         tableView.dataSource = configuration
         tableView.estimatedRowHeight = 100
-        tableView.separatorInset = .zero
+        tableView.separatorInset = .init(top: 0, left: 10, bottom: 0, right: 0)
         return tableView
     }()
 


### PR DESCRIPTION
- Implement showing deboogger by 2 taps of 4 touches
- Implement hiding deboogger with same gesture if it is opened
- Fix section insets
- Implement always showing deboogger button in simulator
- Implement predefined deboogger plugin to show/hide deboogger button on screen (only for devices). The plugin is wrapped into "Deboogger settings" section. If user provide sections they will be shown as expected. If not - all plugins will be wrapped into "App plugins" section

<p align="center">
<img src="https://user-images.githubusercontent.com/3423650/55621719-1ccc5000-57c0-11e9-8351-5fb6cc7f8357.jpeg" width="250" />
</p>