### PR TITLE
Fix app crash on deboogger call

### DIFF
--- a/Sources/PluginViewController/PluginViewController.swift
+++ b/Sources/PluginViewController/PluginViewController.swift
@@ -24,7 +24,7 @@ final class PluginViewController: UIViewController {
 
     private(set) lazy var searchBar: UISearchBar = {
         let view = UISearchBar()
-        view.searchTextField.returnKeyType = .done
+        view.returnKeyType = .done
         view.delegate = self
         view.isHidden = true
         return view


### PR DESCRIPTION
## Reason 
I faced with app crash when was trying to display deboogger window:
`-[UISearchBar searchTextField]: unrecognized selector sent to instance 0x...` 
While i debug the app i find that `searchBar` apply `returnKeyType` to `searchTextField` instead of  `searchBar` itself. 